### PR TITLE
Script for enabling ds18b20 1-wire sensors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+documentation/pdf_format/.DS_Store

--- a/add_on/GPIO_ds18b20/README.md
+++ b/add_on/GPIO_ds18b20/README.md
@@ -1,0 +1,7 @@
+# 1-Wire ds18b20 sensors
+Script to enable the use of ds18b20 sensors directly wired to the GPIO of the Rasberry Pi. This script automates the steps described [here](https://www.pihome.eu/2017/10/11/ds18b20-temperature-sensor-with-raspberry-pi/).
+
+## Quick Start
+1. Execute the install.sh bash script this will:
+   * Update the AirMax database check every 60sec that the temperature is been acquired from the wired ds18b20 sensors
+   * Check that the 1-Wire kernel module is loaded, if not configure the system to load it at boot and reboot the system.

--- a/add_on/GPIO_ds18b20/db_config.py
+++ b/add_on/GPIO_ds18b20/db_config.py
@@ -1,0 +1,25 @@
+import MySQLdb as mdb
+import configparser
+
+# Initialise the database access variables
+config = configparser.ConfigParser()
+config.read('/var/www/st_inc/db_config.ini')
+dbhost = config.get('db', 'hostname')
+dbuser = config.get('db', 'dbusername')
+dbpass = config.get('db', 'dbpassword')
+dbname = config.get('db', 'dbname')
+
+con = mdb.connect(dbhost, dbuser, dbpass, dbname)
+cur = con.cursor()
+
+# Check if there is already a record in the job table
+cur.execute("SELECT COUNT(*) FROM jobs WHERE `script` = '/var/www/cron/check_ds18b20.php'")
+row_count = cur.fetchone()[0]
+val = ("/var/www/cron/check_ds18b20.php", "1", "60", "check_ds18b20")
+if row_count == 0:
+        cur.execute("INSERT INTO jobs (`script`, `enabled`, `time`, `job_name`) VALUES (%s, %s, %s, %s)", val)
+else:
+        cur.execute("UPDATE `jobs` SET `script` = (%s), `enabled` = (%s), `time` = (%s) WHERE `job_name` = (%s);", val)
+con.commit()
+cur.close()
+con.close()

--- a/add_on/GPIO_ds18b20/install.sh
+++ b/add_on/GPIO_ds18b20/install.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+echo "Updating the Jobs in the database"
+python3 db_config.py
+
+echo "Restarting scheduler"
+systemctl restart pihome_jobs_schedule.service
+
+if lsmod | grep w1_gpio &> /dev/null ;
+then
+    echo "The 1-Wire kernel module is loaded"
+else
+    if [ 'grep 'dtoverlay=w1-gpio' /boot/config.txt' ]
+        then
+            modprobe w1-gpio
+            modprobe w1-therm
+            echo "The 1-Wire kernel module is now loaded"
+            echo "w1-gpio" >> /etc/modules
+            echo "w1-therm" >> /etc/modules
+    else
+            echo "Editing /boot/config.txt to load the 1-Wire kernel module at boot"
+            echo "dtoverlay=w1-gpio" >> /boot/config.txt
+            echo "w1-gpio" >> /etc/modules
+            echo "w1-therm" >> /etc/modules
+            echo "Rebooting the system"
+            reboot
+    fi
+fi
+
+
+
+
+

--- a/add_on/MySensors_RPi_Gateway/install.sh
+++ b/add_on/MySensors_RPi_Gateway/install.sh
@@ -26,3 +26,6 @@ systemctl start mysgw.service
 echo "Updating Gateway configuration in the database"
 cd ..
 python3 db_config.py
+
+echo "Restarting scheduler"
+systemctl restart pihome_jobs_schedule.service


### PR DESCRIPTION
Script to automate the process of [enabling ds18b20 1-wire sensors](https://www.pihome.eu/2017/10/11/ds18b20-temperature-sensor-with-raspberry-pi/) and updating the database with a job to check every 60sec that the acquisition from ds18b20 1-wire sensors is running.