### PR TITLE
MQTT Nodes

### DIFF
--- a/MySQL_Database/database_updates/200921.sql
+++ b/MySQL_Database/database_updates/200921.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS `mqtt_node_child` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `child_id` tinyint(4) NOT NULL,
+  `node_id` tinyint(4) NOT NULL,
+  `type` tinyint(4) NOT NULL COMMENT '0 - Sensor, 1 - Relay',
+  `purge` tinyint(4) NOT NULL DEFAULT '0' COMMENT 'Mark For Deletion',
+  `name` char(50) COLLATE utf8_bin DEFAULT NULL,
+  `mqtt_topic` CHAR(50) NOT NULL COLLATE utf8_bin DEFAULT NULL COMMENT 'Relay payload for on command',
+  `on_payload` char(50) COLLATE utf8_bin DEFAULT NULL COMMENT 'Relay payload for on command',
+  `off_payload` char(50) COLLATE utf8_bin DEFAULT NULL COMMENT 'Relay payload for on command',
+  `attribute` char(50) COLLATE utf8_bin DEFAULT NULL COMMENT 'Sensor JSON attribute',
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4;

--- a/cron/controller.php
+++ b/cron/controller.php
@@ -1597,9 +1597,9 @@ for ($row = 0; $row < count($zone_commands); $row++){
 			}
 
 			/***************************************************************************************
-			Zone Valve Wireless Section: MySensors Wireless Relay module for your Zone Valve control.
+			Zone Valve Wireless Section: MySensors Wireless or MQTT Relay module for your Zone Valve control.
 			****************************************************************************************/
-			if ($zone_controller_type == 'MySensor'){
+			if ($zone_controller_type == 'MySensor' || $zone_controller_type == 'MQTT'){
 				//update messages_out table with sent status to 0 and payload to as zone status.
 				$query = "UPDATE messages_out SET sent = '0', payload = '{$zone_command}' WHERE node_id ='$zone_controler_id' AND child_id = '$zone_controler_child_id' LIMIT 1;";
 				$conn->query($query);
@@ -1694,22 +1694,22 @@ if (in_array("1", $system_controller)) {
 		}
 
 		/**************************************************************************************************
-		System Controller Wirelss Section:	MySensors Wireless Relay module for your System Controller
+		System Controller Wirelss Section:	MySensors Wireless or MQTT Relay module for your System Controller
 		***************************************************************************************************/
 		//update messages_out table with sent status to 0 and payload to as system controller status.
                 if ($sc_mode != 3) { //process if NOT  HVAC fan only mode
-	        	if ($system_controller_mode == 1 && $off_relay_type == 'MySensor'){
+	        	if ($system_controller_mode == 1 && ($off_relay_type == 'MySensor' || $off_relay_type == 'MQTT')){
         	        	$query = "UPDATE messages_out SET sent = '0', payload = '0' WHERE node_id ='{$off_relay_id}' AND child_id = '{$off_relay_child_id}' LIMIT 1;";
 	        	        $conn->query($query);
         	        	echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - System Controller Node ID: \033[41m".$off_relay_id."\033[0m Child ID: \033[41m".$off_relay_child_id."\033[0m \n";
 		        }
-			if ($on_relay_type == 'MySensor'){
+			if ($on_relay_type == 'MySensor' || $on_relay_type == 'MQTT'){
 				$query = "UPDATE messages_out SET sent = '0', payload = '{$new_system_controller_status}' WHERE node_id ='{$on_relay_id}' AND child_id = '{$on_relay_child_id}' LIMIT 1;";
 				$conn->query($query);
 				echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - System Controller Node ID: \033[41m".$on_relay_id."\033[0m Child ID: \033[41m".$on_relay_child_id."\033[0m \n";
 			}
 		}
-        	if ($system_controller_mode == 1 && $fan_relay_type == 'MySensor'){
+        	if ($system_controller_mode == 1 && ($fan_relay_type == 'MySensor' || $fan_relay_type == 'MQTT')){
         		$query = "UPDATE messages_out SET sent = '0', payload = '{$new_system_controller_status}' WHERE node_id ='{$fan_relay_id}' AND child_id = '{$fan_relay_child_id}' LIMIT 1;";
 	                $conn->query($query);
         	        echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - System Controller Node ID: \033[41m".$fan_relay_id."\033[0m Child ID: \033[41m".$fan_relay_child_id."\033[0m \n";
@@ -1829,9 +1829,9 @@ if (in_array("1", $system_controller)) {
 		$conn->query($query);
 
 		/****************************************************************************************************
-		System Controller Wirelss Section:	MySensors Wireless Relay module for your System Controller
+		System Controller Wirelss Section:	MySensors Wireless or MQTT Relay module for your System Controller
 		*****************************************************************************************************/
-		if ($heat_relay_type == 'MySensor'){
+		if ($heat_relay_type == 'MySensor' || $heat_relay_type == 'MQTT'){
 			//update messages_out table with sent status to 0 and payload to as system controller status.
 			$query = "UPDATE messages_out SET sent = '0', payload = '{$new_system_controller_status}' WHERE node_id ='{$heat_relay_id}' AND child_id = '{$heat_relay_child_id}' LIMIT 1;";
 			$conn->query($query);
@@ -1839,11 +1839,11 @@ if (in_array("1", $system_controller)) {
 		}
         	if ($system_controller_mode == 1){
                 	//update messages_out table with sent status to 0 and payload to as system controller status.
-			if ($cool_relay_type == 'MySensor') { // HVAC cool relay OFF
+			if ($cool_relay_type == 'MySensor' || $cool_relay_type == 'MQTT') { // HVAC cool relay OFF
         	                $query = "UPDATE messages_out SET sent = '0', payload = '0' WHERE node_id ='{$cool_relay_id}' AND child_id = '{$cool_relay_child_id}' LIMIT 1;";
 				$conn->query($query);
 			}
-	                if ($fan_relay_type == 'MySensor') {
+	                if ($fan_relay_type == 'MySensor' || $fan_relay_type == 'MQTT') {
 				if ($sc_mode == 3) { // HVAC fan ON if set to fan mode, else turn OFF
 	        	                $query = "UPDATE messages_out SET sent = '0', payload = '1' WHERE node_id ='{$fan_relay_id}' AND child_id = '{$fan_relay_child_id}' LIMIT 1;";
 				} else {

--- a/cron/gateway.py
+++ b/cron/gateway.py
@@ -40,6 +40,16 @@ import socket, re
 from Pin_Dict import pindict
 import board, digitalio
 import traceback
+import paho.mqtt.client as mqtt
+import json
+import signal
+
+#MQTT Client ID
+MQTT_CLIENT_ID = "Gateway_MaxAir"
+
+mqttClient = None
+
+
 
 # Debug print to screen configuration
 dbgLevel = 3  # 0-off, 1-info, 2-detailed, 3-all
@@ -60,7 +70,7 @@ null_value = None
 relay_dict = {}
 
 
-def set_relays(msg, node_type, out_id, out_child_id, out_on_trigger, out_payload, enable_outgoing):
+def set_relays(msg, node_type, out_id, out_child_id, out_on_trigger, out_payload, enable_outgoing, out_node_id):
     # node-id ; child-sensor-id ; command ; ack ; type ; payload \n
     if node_type.find("MySensor") != -1 and enable_outgoing == 1:  # process normal node
         if gatewaytype == "serial":
@@ -110,7 +120,139 @@ def set_relays(msg, node_type, out_id, out_child_id, out_on_trigger, out_payload
             if x.json().get(cmd) == param:  # clear send if response is okay
                 cur.execute("UPDATE `messages_out` set sent=1 where id=%s", [out_id])
                 con.commit()  # commit above
+    elif node_type.find("MQTT") != -1 and MQTT_CONNECTED == 1:  # process MQTT mode
+        cur.execute('SELECT `mqtt_topic`, `on_payload`, `off_payload`  FROM `mqtt_node_child` WHERE `type` = "1" AND `node_id` = (%s) AND `child_id` = (%s) LIMIT 1', [out_node_id, out_child_id])
+        results_mqtt_r = cur.fetchone()
+        mqtt_topic = results_mqtt_r[0]
+        if out_payload == "1":
+            payload_str = results_mqtt_r[1]
+        else:
+            payload_str = results_mqtt_r[2]
+        print("Sending the following MQTT Message:")
+        print("Topic: %s" % mqtt_topic)
+        print("Message: %s" % payload_str)
+        mqttClient.publish(
+            topic=mqtt_topic,
+            payload=payload_str,
+            qos=1,
+            retain=False,
+        )
+        cur.execute(
+            "UPDATE `messages_out` set sent=1 where id=%s", [out_id]
+        )  # update DB so this message will not be processed in next loop
+        con.commit()  # commit above
 
+#To be run once connected to the MQTT brooker
+def on_connect(client, userdata, flags, rc):
+    if rc == 0:
+        print("Connected to broker")
+        subscribe_topics = []
+        cur_mqtt.execute('SELECT DISTINCT `mqtt_topic` FROM `mqtt_node_child` WHERE `type` = "0"')
+        for node in cur_mqtt.fetchall():
+            subscribe_topics.append((f"{node[0]}", 0))
+        print("Subscribed to the followint MQTT topics:")
+        print(subscribe_topics)
+        client.subscribe(subscribe_topics)
+    else:
+        print("Connection failed")
+
+#To be run when an MQTT message is received to write the sensor value into messages_in
+def on_message(client, userdata, message):
+    print("MQTT messaged received.")
+    print("Topic: %s" % message.topic)
+    print("Message: %s" % message.payload.decode())
+    cur_mqtt.execute('SELECT `node_id`, `child_id`, `attribute`  FROM `mqtt_node_child` WHERE `mqtt_topic` = (%s)', [message.topic])
+    for child in cur_mqtt.fetchall():    
+        mqtt_node_id = child[0]   
+        mqtt_child_sensor_id = child[1]
+        if child[2] is None:
+            mqtt_payload = message.payload.decode()
+        else:
+            json_data = json.loads(message.payload.decode())
+            mqtt_payload = json_data[child[2]]
+        print(
+                "5: Adding Temperature Reading From Node ID:",
+                mqtt_node_id,
+                " Child Sensor ID:",
+                mqtt_child_sensor_id,
+                " PayLoad:",
+                mqtt_payload,
+            )
+        cur_mqtt.execute('INSERT INTO `messages_in`(`node_id`, `sync`, `purge`, `child_id`, `sub_type`, `payload`, `datetime`) VALUES (%s, 0, 0, %s, 0, %s, NOW())', [mqtt_node_id, mqtt_child_sensor_id, mqtt_payload])
+        con_mqtt.commit()
+        cur_mqtt.execute('UPDATE `nodes` SET `last_seen`= NOW() WHERE `node_id`= "%s"', [mqtt_node_id])
+        con_mqtt.commit() 
+        # Check is sensor is attached to a zone which is being graphed
+        cur_mqtt.execute('SELECT sensors.id, sensors.zone_id, nodes.node_id, sensors.sensor_child_id, sensors.name, sensors.graph_num FROM sensors, `nodes` WHERE (sensors.sensor_id = nodes.`id`) AND  nodes.node_id = "%s" AND sensors.sensor_child_id = (%s) AND sensors.graph_num > 0 LIMIT 1;', [mqtt_node_id, mqtt_child_sensor_id])
+        results = cur_mqtt.fetchone()
+        if cur_mqtt.rowcount > 0:
+            mqtt_sensor_to_index = dict((d[0], i) for i, d in enumerate(cur_mqtt.description))
+            mqtt_sensor_id = int(results[mqtt_sensor_to_index["id"]])
+            mqtt_sensor_name = results[mqtt_sensor_to_index["name"]]
+            mqtt_zone_id = results[mqtt_sensor_to_index["zone_id"]]
+            # type = results[zone_view_to_index['type']]
+            # category = int(results[zone_view_to_index['category']])
+            mqtt_graph_num = int(results[mqtt_sensor_to_index["graph_num"]])
+            if mqtt_graph_num > 0:
+                if dbgLevel >= 2 and dbgMsgIn == 1:
+                    print(
+                        "5a: Adding Temperature Reading to Graph Table From Node ID:",
+                        mqtt_node_id,
+                        " Child Sensor ID:",
+                        mqtt_child_sensor_id,
+                        " PayLoad:",
+                        mqtt_payload,
+                    )
+                if mqtt_zone_id == 0:
+                    cur_mqtt.execute(
+                        'INSERT INTO zone_graphs(`sync`, `purge`, `zone_id`, `name`, `type`, `category`, `node_id`,`child_id`, `sub_type`, `payload`, `datetime`) VALUES(%s,%s,%s,%s,%s,%s,"%s",%s,%s,%s,NOW())',
+                        (
+                            0,
+                            0,
+                            mqtt_sensor_id,
+                            mqtt_sensor_name,
+                            "Sensor",
+                            0,
+                            mqtt_node_id,
+                            mqtt_child_sensor_id,
+                            0,
+                            mqtt_payload,
+                        ),
+                    )
+                    con_mqtt.commit()
+                else:
+                    cur_mqtt.execute('SELECT * FROM `zone_view` where id = "%s" LIMIT 1;', [mqtt_zone_id])
+                    results = cur_mqtt.fetchone()
+                    if cur_mqtt.rowcount > 0:
+                        mqtt_zone_view_to_index = dict((d[0], i) for i, d in enumerate(cur_mqtt.description))
+                        mqtt_zone_name = results[mqtt_zone_view_to_index["name"]]
+                        mqtt_type = results[mqtt_zone_view_to_index["type"]]
+                        mqtt_category = int(results[mqtt_zone_view_to_index["category"]])
+                        if mqtt_category < 2:
+                            cur_mqtt.execute(
+                                'INSERT INTO zone_graphs(`sync`, `purge`, `zone_id`, `name`, `type`, `category`, `node_id`,`child_id`, `sub_type`, `payload`, `datetime`) VALUES(%s,%s,%s,%s,%s,%s,"%s",%s,%s,%s,NOW())',
+                                (
+                                    0,
+                                    0,
+                                    mqtt_sensor_id,
+                                    mqtt_zone_name,
+                                    mqtt_type,
+                                    mqtt_category,
+                                    mqtt_node_id,
+                                    mqtt_child_sensor_id,
+                                    0,
+                                    mqtt_payload,
+                                ),
+                            )
+                            con_mqtt.commit()
+                cur_mqtt.execute('DELETE FROM zone_graphs WHERE node_id = "%s" AND child_id = (%s) AND datetime < CURRENT_TIMESTAMP - INTERVAL 24 HOUR;', [mqtt_node_id, mqtt_child_sensor_id])
+                con_mqtt.commit()
+
+class ProgramKilled(Exception):
+    pass
+
+def signal_handler(signum, frame):
+    raise ProgramKilled
 
 try:
     # Initialise the database access variables
@@ -123,6 +265,8 @@ try:
 
     con = mdb.connect(dbhost, dbuser, dbpass, dbname)
     cur = con.cursor()
+    con_mqtt = mdb.connect(dbhost, dbuser, dbpass, dbname)
+    cur_mqtt = con_mqtt.cursor()
     cur.execute("SELECT * FROM gateway where status = 1 order by id asc limit 1")
     row = cur.fetchone()
     gateway_to_index = dict((d[0], i) for i, d in enumerate(cur.description))
@@ -175,6 +319,33 @@ try:
     else:
         network_found = 0
 
+    # Initiliaze MQTT connection if the conection has been enabled
+    cur.execute('SELECT * FROM `mqtt` where `type` = 2 AND `enabled` = 1;')
+    if cur.rowcount == 0:
+        # If no MQTT connection has been defined do not connect
+        print("More than one Home Assistant MQTT connections defined in the web interface, please remove the unused ones.")
+        MQTT_CONNECTED = 0
+    else:
+        if (cur.rowcount > 1):
+            # If more than one MQTT connection has been defined do not connect
+            print("More than one Home Assistant MQTT connections defined in the web interface, please remove the unused ones.")
+            MQTT_CONNECTED = 0
+        else:
+            print("Setting up MQTT")
+            results_mqtt =cur.fetchone()
+            MQTT_HOSTNAME = results_mqtt[2]
+            MQTT_PORT = results_mqtt[3]
+            MQTT_USERNAME = results_mqtt[4]
+            MQTT_PASSWORD = results_mqtt[5]
+            mqttClient = mqtt.Client(MQTT_CLIENT_ID)
+            mqttClient.on_connect = on_connect                      #attach function to callback
+            mqttClient.on_message = on_message
+            mqttClient.username_pw_set(MQTT_USERNAME, MQTT_PASSWORD)
+            signal.signal(signal.SIGTERM, signal_handler)
+            signal.signal(signal.SIGINT, signal_handler)
+            mqttClient.connect(MQTT_HOSTNAME, MQTT_PORT)
+            mqttClient.loop_start()
+            MQTT_CONNECTED = 1
     # re-sync any setup relays
     cur.execute("SELECT COUNT(*) FROM `relays`")
     count = cur.fetchone()
@@ -196,6 +367,7 @@ try:
             nd = cur.fetchone()
             node_to_index = dict((d[0], i) for i, d in enumerate(cur.description))
             out_id = nd[node_to_index["node_id"]]
+            out_node_id = nd[node_to_index["node_id"]]
             node_type = nd[node_to_index["type"]]
             cur.execute(
                 "SELECT `sub_type`, `ack`, `type`, `payload` FROM `messages_out` where node_id = (%s) AND child_id = (%s) ORDER BY id DESC LIMIT 1",
@@ -220,7 +392,7 @@ try:
             msg += str(out_payload)  # Payload from DB
             msg += " \n"  # New line
             set_relays(
-                msg, node_type, out_id, out_child_id, out_on_trigger, out_payload, gatewayenableoutgoing
+                msg, node_type, out_id, out_child_id, out_on_trigger, out_payload, gatewayenableoutgoing, out_node_id
             )
             ping_timer = time.time()
     else:
@@ -316,7 +488,7 @@ try:
 
             # node-id ; child-sensor-id ; command ; ack ; type ; payload \n
             set_relays(
-                msg, node_type, out_id, out_child_id, out_on_trigger, out_payload, gatewayenableoutgoing
+                msg, node_type, out_id, out_child_id, out_on_trigger, out_payload, gatewayenableoutgoing, out_node_id 
             )
 
         ## Incoming messages
@@ -1058,21 +1230,45 @@ try:
 
 except configparser.Error as e:
     print("ConfigParser:", format(e))
+    mqttClient.disconnect()
+    mqttClient.loop_stop()
+    con_mqtt.close()
     con.close()
 except mdb.Error as e:
     print("DB Error %d: %s" % (e.args[0], e.args[1]))
+    mqttClient.disconnect()
+    mqttClient.loop_stop()
+    con_mqtt.close()
     con.close()
 except serial.SerialException as e:
     print("SerialException:", format(e))
+    mqttClient.disconnect()
+    mqttClient.loop_stop()
+    con_mqtt.close()
     con.close()
 except EOFError as e:
     print("EOFError:", format(e))
+    mqttClient.disconnect()
+    mqttClient.loop_stop()
+    con_mqtt.close()
     con.close()
 except TypeError:
     print(traceback.format_exc())
+    mqttClient.disconnect()
+    mqttClient.loop_stop()
+    con_mqtt.close()
     con.close()
 except Exception as e:
     print(format(e))
+    mqttClient.disconnect()
+    mqttClient.loop_stop()
+    con_mqtt.close()
+    con.close()
+except ProgramKilled:
+    write_message_to_console("Program killed: running cleanup code")
+    mqttClient.disconnect()
+    mqttClient.loop_stop()
+    con_mqtt.close()
     con.close()
 finally:
     print(infomsg)


### PR DESCRIPTION
This is my attempt to implement support for MQTT Nodes, both sensors and relays. At this stage this is just the backend: the web interface has not been modified yet to support this and the MQTT nodes and child need to be setup directly in the database.
I have tried to keep the implementation as generic and configurable as possible to support as many types of devices as possible. I have been testing this with a [TuYa TS0601 TRV](https://www.zigbee2mqtt.io/devices/TS0601_thermostat.html) connected via zigbee2mqtt. Please review this pull request in details as changes have been made to `controller.php` and `gateway.py`

### Database
A new table is added to the database `mqtt_node_child`. This table has a record for each child of each MQTT node. This table is used to specify the child type (sensor or relay), MQTT topic, On & Off payloads to be sent for relays nodes and json attribute (if any) to extract the value for sensor child.

### controller.php
The controller.php has been modified to treat the outgoing messages for MQTT nodes the same way as the messages for MySensors nodes. These are added to the `message_out` table.

### gateway.py
**set_relays(msg, node_type, out_id, out_child_id, out_on_trigger, out_payload, enable_outgoing, out_node_id)**
The function has been modified take an additional parameter `out_node_id` this is the ID of the node.

**Lines 123 to 143**
These lines have been added to process the out going messages for MQTT nodes. Records in the `message_out` table for MQTT nodes are processed sending over MQTT the payload specified in the `mqtt_node_child` table for the node/child.

**on_connect(client, userdata, flags, rc)**
This function is executed when connecting to the MQTT broker. It subscribes the MaxAir MQTT client to the topics specified in the `mqtt_node_child` table for the MQTT sensors nodes/child.

**on_message(client, userdata, message)**
This function is called when a new message is published to a topic to which the MaxAir MQTT client is subscribed (i.e. each time a MQTT sensor specified in the  `mqtt_node_child` table pushes a new value). The MQTT message is processed extracting the json attribute specified in the `mqtt_node_child` table (if applicable) and the sensor reading is then added to the `messages_in` table. The `nodes` table is also updated with the "last seen" timestamp and the sensor value is added to the `zone_graphs` if the sensor is associated to to a zone to be graphed.

**Lines 322 to 348**
These lines create the connection to the database used to write the incoming MQTT messages. A separate connection is needed for this as the `on_message()` function can be called at any time while the main connection to the database could be in use.

**Lines 322 to 348**
These lines retrieve the MQTT connection details from the `mqtt` table and initialize the connection to the MQTT broker.

### Setup
**Database**
Add the `mqtt_node_child` table as per `MySQL_Database/database_updates/200921.sql`

**MQTT connection**
On the web interface go to Settings > System Configuration > MQTT and add an MQTT connection selecting "MQTT Node" as type. There should be only one MQTT connection of this type defined at any time.

**Adding an MQTT node to the database**
At this time there is no web interface to add the MQTT nodes. There are two _"sub types"_ of MQTT nodes:
- NAME = MQTT Controller => These nodes support one or more MQTT relay(s) as child
- NAME = MQTT Sensor => These nodes support one or more MQTT sensor(s) as child

For each node a record needs to be added to the `nodes` table as in the example below:
![nodes](https://user-images.githubusercontent.com/62815008/134036311-442c45da-237a-4a20-9ed9-d531843ef07d.png)

For each MQTT node the child devices need to be specified in the `mqtt_node_child` table. Each child device requires a record in this table:
- child_id => ID for the node child starting from 0
- node_id => Node ID of the MQTT node
- type => 0 for sensors and 1 for relays. MQTT Controller nodes can have only relays as child devices (type = 1) and MQTT Sensors nodes can have only sensors as child devices (type = 0)
- name => Friendly name
- mqtt_topic => This is the topic to which MaxAir should subscribe for MQTT sensors or to which it should publish the On/Off payloads for MQTT relays
- on_payload => NULL for sensor child. For relay child this is the payload to be sent to the mqtt_topic to switch on the relay.
- off_payload => NULL for sensor child. For relay child this is the payload to be sent to the mqtt_topic to switch off the relay.
- attribute => NULL for relay child. For sensor child this is optional. This needs to be specified if the MQTT sensors sends the payload in json format, in this case this is the json attribute to be extracted.
Please see the `mqtt_node_child` example below for a sensor and relay MQTT child.
![mqtt_nodes_child](https://user-images.githubusercontent.com/62815008/134038014-4abd367e-4444-4ee5-8626-f8af0ebe3c2b.png)

Once the nodes and child devices have been created the sensors and relays can be added as normal through the web interface. 
 
