### PR TITLE
Fix MQTT password encryption

### DIFF
--- a/add_on/HomeAssistant/HA_HVAC_integration.py
+++ b/add_on/HomeAssistant/HA_HVAC_integration.py
@@ -1123,7 +1123,7 @@ if __name__ == "__main__":
             MQTT_PORT = results[description_to_index["port"]]
             MQTT_USERNAME = results[description_to_index["username"]]
             result = subprocess.run(
-                ['php', '/var/www/cron/mqtt_passwd_decrypt.php'],         # program and arguments
+                ['php', '/var/www/cron/mqtt_passwd_decrypt.php', '3'],         # program and arguments
                 stdout=subprocess.PIPE,                     # capture stdout
                 check=True                                  # raise exception if program fails
             )

--- a/cron/gateway.py
+++ b/cron/gateway.py
@@ -416,7 +416,7 @@ try:
                 MQTT_PORT = results_mqtt[description_to_index["port"]]
                 MQTT_USERNAME = results_mqtt[description_to_index["username"]]
                 result = subprocess.run(
-                    ['php', '/var/www/cron/mqtt_passwd_decrypt.php'],         # program and arguments
+                    ['php', '/var/www/cron/mqtt_passwd_decrypt.php', '2'],         # program and arguments
                     stdout=subprocess.PIPE,                     # capture stdout
                     check=True                                  # raise exception if program fails
                 )
@@ -428,8 +428,10 @@ try:
                 mqttClient.username_pw_set(MQTT_USERNAME, MQTT_PASSWORD)
                 signal.signal(signal.SIGTERM, signal_handler)
                 signal.signal(signal.SIGINT, signal_handler)
-                mqttClient.connect(MQTT_HOSTNAME, MQTT_PORT)
-                mqttClient.loop_start()
+                if MQTT_CONNECTED == 0:
+                    mqttClient.connect(MQTT_HOSTNAME, MQTT_PORT)
+                    mqttClient.loop_start()
+
     else:
         # If no MQTT connection has been defined do not connect
         print(
@@ -814,7 +816,7 @@ try:
                             (payload, node_id),
                         )
                         con.commit()
-
+                    
                         # ..::Step Three ::..
                         # Add Nodes Sketch Version to Nodes Table.
                     if (

--- a/cron/gateway.py
+++ b/cron/gateway.py
@@ -407,7 +407,6 @@ try:
                 con_mqtt = mdb.connect(dbhost, dbuser, dbpass, dbname)
                 cur_mqtt = con_mqtt.cursor()
                 MQTT_CLIENT_ID = "Gateway_MaxAir"  # MQTT Client ID
-                MQTT_CONNECTED = 1
                 results_mqtt = cur.fetchone()
                 description_to_index = dict(
                     (d[0], i) for i, d in enumerate(cur.description)
@@ -428,9 +427,9 @@ try:
                 mqttClient.username_pw_set(MQTT_USERNAME, MQTT_PASSWORD)
                 signal.signal(signal.SIGTERM, signal_handler)
                 signal.signal(signal.SIGINT, signal_handler)
-                if MQTT_CONNECTED == 0:
-                    mqttClient.connect(MQTT_HOSTNAME, MQTT_PORT)
-                    mqttClient.loop_start()
+                mqttClient.connect(MQTT_HOSTNAME, MQTT_PORT)
+                mqttClient.loop_start()
+                MQTT_CONNECTED = 1
 
     else:
         # If no MQTT connection has been defined do not connect

--- a/cron/mqtt_passwd_decrypt.php
+++ b/cron/mqtt_passwd_decrypt.php
@@ -4,7 +4,17 @@
 require_once(__DIR__.'../../st_inc/connection.php');
 require_once(__DIR__.'../../st_inc/functions.php');
 
-$query = "SELECT `password` FROM mqtt LIMIT 1;";
+switch ($argv[1]) {
+        case "2":
+          $query = "SELECT `password` FROM mqtt WHERE `type` = 2 AND `enabled` = 1 LIMIT 1;";
+          break;
+        case "3":
+          $query = "SELECT `password` FROM mqtt WHERE `type` = 3 AND `enabled` = 1 LIMIT 1;";
+          break;
+        default:
+          $query = "SELECT `password` FROM mqtt LIMIT 0;";
+      }
+
 $result = $conn->query($query);
 if (mysqli_num_rows($result) > 0){
         $row = mysqli_fetch_assoc($result);


### PR DESCRIPTION
Fixed an issue that was introduced with the encryption of the MQTT password in the database that was causing both gateway.py and HA_HVAC_integration.py to use the password from the first row in the mqtt table.
Mqtt_passwd_decrypt.php has been modified to take an argument as input to specify if the password for the MQTT sensors account or the password for the HA  integration account should be retrieved from the mqtt table. Gateway.py and HA_HVAC_integration.py have been modified to call mqtt_passwd_decrypt.php with the correct argument.