### PR TITLE
fix notice.py: get PASS

### DIFF
--- a/cron/notice.py
+++ b/cron/notice.py
@@ -63,7 +63,7 @@ try:
             stdout=subprocess.PIPE,                     # capture stdout
             check=True                                  # raise exception if program fails
         )
-#        PASS = result.stdout.decode("utf-8").split()[0] # result.stdout contains a byte-string
+        PASS = result.stdout.decode("utf-8").split()[0] # result.stdout contains a byte-string
         HOST = results[name_to_index['smtp']]
         PORT = results[name_to_index['port']]
         TO = results[name_to_index['to']]


### PR DESCRIPTION
Password is necessary to send any notice